### PR TITLE
fix: Change layering in GUI UI to allow buttons to always be clickable

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - os: linux
-            runner: ubuntu-20
+            runner: ubuntu-20.04
           - os: macos
             runner: macos-latest
           - os: windows

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - os: linux
-            runner: ubuntu-latest
+            runner: ubuntu-20
           - os: macos
             runner: macos-latest
           - os: windows

--- a/src/react/components/VersionFooter.tsx
+++ b/src/react/components/VersionFooter.tsx
@@ -16,6 +16,7 @@ const SoftText = styled(Typography)`
 const Container = styled.div`
   position: fixed;
   bottom: 35;
+  z-index: -1;
   width: 100%;
 `;
 
@@ -25,28 +26,47 @@ const LinksTag = styled.a`
 
 /**
  * This component is a footer used to display the version and commit hash.
- * 
+ *
  * @returns the footer component containing the version and commit hash
  */
 const VersionFooter = () => {
-  return(
+  return (
     <Container>
       <Grid container>
         <Grid item xs={2} />
         <Grid item xs={8}>
           <SoftText>
-            GUI: {VERSION} <LinksTag target="_blank" href={`https://github.com/lukso-network/tools-wagyu-key-gen/tree/${CLICOMMITHASH}`}>#{COMMITHASH}</LinksTag>
-            <br/>
-            Deposit-CLI: {CLIVERSION} <LinksTag target="_blank" href={`https://github.com/lukso-network/tools-staking-deposit-cli/tree/${CLICOMMITHASH}`}>#{CLICOMMITHASH}</LinksTag>
-            <br/>
-            <br/>
-            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+            GUI: {VERSION}{" "}
+            <LinksTag
+              target="_blank"
+              href={`https://github.com/lukso-network/tools-wagyu-key-gen/tree/${CLICOMMITHASH}`}
+            >
+              #{COMMITHASH}
+            </LinksTag>
+            <br />
+            Deposit-CLI: {CLIVERSION}{" "}
+            <LinksTag
+              target="_blank"
+              href={`https://github.com/lukso-network/tools-staking-deposit-cli/tree/${CLICOMMITHASH}`}
+            >
+              #{CLICOMMITHASH}
+            </LinksTag>
+            <br />
+            <br />
+            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+            EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+            MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+            NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+            BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+            ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+            CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+            SOFTWARE.
           </SoftText>
         </Grid>
         <Grid item xs={2} />
       </Grid>
     </Container>
-  )
-}
+  );
+};
 
 export default VersionFooter;


### PR DESCRIPTION
The VersionFooter area had a higher z-index than the button area
because it's defined later in the UI. Added a z-index: -1 to put the area
slighly below the command buttons.
