### PR TITLE
fix: Redo the way we package and run the python binary to allow a real universal2 build

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,7 @@
       "target": {
         "target": "default",
         "arch": [
-          "x64",
-          "arm64"
+          "x64"
         ]
       }
     },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
       "target": {
         "target": "default",
         "arch": [
-          "x64"
+          "universal"
         ]
       }
     },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "extraFiles": [
       "build/bin/*",
       {
-        "from": ".build/bin-${arch}/eth2deposit_proxy",
+        "from": ".build/${arch}/eth2deposit_proxy",
         "to": "build/bin/eth2deposit_proxy"
       },
       "build/word_lists/*",
@@ -80,7 +80,10 @@
       "gatekeeperAssess": false,
       "target": {
         "target": "default",
-        "arch": "universal"
+        "arch": [
+          "x64",
+          "arm64"
+        ]
       }
     },
     "dmg": {

--- a/src/electron/Eth2Deposit.ts
+++ b/src/electron/Eth2Deposit.ts
@@ -70,13 +70,23 @@ const DIST_WORD_LIST_PATH = path.join(cwd(), "build", "word_lists");
 /**
  * Paths needed to call the eth2deposit_proxy application from a bundled application.
  */
-const BUNDLED_SFE_PATH = path.join(
-  process.resourcesPath,
-  "..",
-  "build",
-  "bin",
-  "eth2deposit_proxy" + (process.platform == "win32" ? ".exe" : "")
-);
+const BUNDLED_SFE_PATH =
+  process.platform === "darwin"
+    ? path.join(
+        process.resourcesPath,
+        "..",
+        "build",
+        "bin",
+        "eth2deposit_proxy/eth2deposit_proxy"
+      )
+    : path.join(
+        process.resourcesPath,
+        "..",
+        "build",
+        "bin",
+        "eth2deposit_proxy" + (process.platform === "win32" ? ".exe" : "")
+      );
+
 const BUNDLED_DIST_WORD_LIST_PATH = path.join(
   process.resourcesPath,
   "..",

--- a/src/scripts/bundle_proxy_mac.sh
+++ b/src/scripts/bundle_proxy_mac.sh
@@ -17,18 +17,18 @@ ETH2DEPOSITCLIPATH=$SCRIPTPATH/../vendors/$EDCDIR
 ETH2REQUIREMENTSPATH=$ETH2DEPOSITCLIPATH/requirements.txt
 
 PYTHONPATH=$TARGETPACKAGESPATH:$ETH2DEPOSITCLIPATH:$(python3 -c "import sys;print(':'.join(sys.path))")
+echo $PYTHONPATH
 DISTBINPATH=$SCRIPTPATH/../../build/bin
 DISTWORDSPATH=$SCRIPTPATH/../../build/word_lists
 SRCWORDSPATH=$SCRIPTPATH/../vendors/$EDCDIR/staking_deposit/key_handling/key_derivation/word_lists
 SRCINTLPATH=$SCRIPTPATH/../vendors/$EDCDIR/staking_deposit/intl
-DISTARCHROOTPATH=$SCRIPTPATH/../../.build
-DISTX64ARCHPATH=$DISTARCHROOTPATH/x64
-DISTARM64ARCHPATH=$DISTACHROOTPATH/arm64
+DISTARCHPATH=$SCRIPTPATH/../../.build
+DISTARMPATH=$DISTARCHPATH/arm64
+DISTX64PATH=$DISTARCHPATH/x64
 
-rm -rf $DISTARCHROOTPATH
-rm -rf $DISTBINPATH
-mkdir -p $DISTX64ARCHPATH
-mkdir -p $DISTARM64ARCHPATH
+mkdir -p $DISTARMPATH
+mkdir -p $DISTX64PATH
+mkdir -p $DISTBINPATH
 mkdir -p $DISTWORDSPATH
 mkdir -p $TARGETPACKAGESPATH
 
@@ -39,17 +39,18 @@ python3 -m pip install -r $ETH2REQUIREMENTSPATH --target $TARGETPACKAGESPATH
 # Bundling Python eth2deposit_proxy
 PYTHONPATH=$PYTHONPATH pyinstaller \
     --onefile \
-    --distpath $DISTX64ARCHPATH \
+    --distpath $DISTX64PATH \
     --target-arch x86_64 \
     --add-data "$SRCINTLPATH:staking_deposit/intl" \
     -p $PYTHONPATH \
     $SCRIPTPATH/eth2deposit_proxy.py
-PYTHONPATH=$PYTHONPATH pyinstaller \
-    --onefile \
-    --distpath $DISTARM64ARCHPATH \
-    --target-arch arm64 \
-    --add-data "$SRCINTLPATH:staking_deposit/intl" \
-    -p $PYTHONPATH \
-    $SCRIPTPATH/eth2deposit_proxy.py
+# PYTHONPATH=$PYTHONPATH pyinstaller \
+#     --onefile \
+#     --distpath $DISTARMPATH \
+#     --target-arch arm64 \
+#     --add-data "$SRCINTLPATH:staking_deposit/intl" \
+#     -p $PYTHONPATH \
+#     $SCRIPTPATH/eth2deposit_proxy.py
+
 # Adding word list
 cp $SRCWORDSPATH/* $DISTWORDSPATH

--- a/src/scripts/bundle_proxy_mac.sh
+++ b/src/scripts/bundle_proxy_mac.sh
@@ -13,10 +13,11 @@ SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 EDCDIR=tools-key-gen-cli
 
 TARGETPACKAGESPATH=$SCRIPTPATH/../../dist/packages
+TARGETPACKAGESMACPATH=$SCRIPTPATH/../../dist/packages.mac
 ETH2DEPOSITCLIPATH=$SCRIPTPATH/../vendors/$EDCDIR
 ETH2REQUIREMENTSPATH=$ETH2DEPOSITCLIPATH/requirements.txt
 
-PYTHONPATH=$TARGETPACKAGESPATH:$ETH2DEPOSITCLIPATH:$(python3 -c "import sys;print(':'.join(sys.path))")
+PYTHONPATH=$TARGETPACKAGESMACPATH:$TARGETPACKAGESPATH:$ETH2DEPOSITCLIPATH:$(python3 -c "import sys;print(':'.join(sys.path))")
 echo $PYTHONPATH
 DISTBINPATH=$SCRIPTPATH/../../build/bin
 DISTWORDSPATH=$SCRIPTPATH/../../build/word_lists
@@ -26,31 +27,38 @@ DISTARCHPATH=$SCRIPTPATH/../../.build
 DISTARMPATH=$DISTARCHPATH/arm64
 DISTX64PATH=$DISTARCHPATH/x64
 
+rm -rf $DISTARCHPATH
+rm -rf $TARGETPACKAGESPATH
+rm -rf $TARGETPACKAGESMACPATH
 mkdir -p $DISTARMPATH
 mkdir -p $DISTX64PATH
 mkdir -p $DISTBINPATH
 mkdir -p $DISTWORDSPATH
 mkdir -p $TARGETPACKAGESPATH
+mkdir -p $TARGETPACKAGESMACPATH
 
 # Getting all the requirements
 echo "Install requirements"
+export ARCHFLAGS='-arch arm64 -arch x86_64'
+
+VERSION=$(sed -n -e 's#\(pycryptodome==[^ ]*\).*#\1#gp' $ETH2REQUIREMENTSPATH)
+echo $VERSION
+python3 -m pip install $VERSION --no-binary :all: --target $TARGETPACKAGESMACPATH
 python3 -m pip install -r $ETH2REQUIREMENTSPATH --target $TARGETPACKAGESPATH
 
 # Bundling Python eth2deposit_proxy
 PYTHONPATH=$PYTHONPATH pyinstaller \
-    --onefile \
     --distpath $DISTX64PATH \
     --target-arch x86_64 \
     --add-data "$SRCINTLPATH:staking_deposit/intl" \
     -p $PYTHONPATH \
     $SCRIPTPATH/eth2deposit_proxy.py
-# PYTHONPATH=$PYTHONPATH pyinstaller \
-#     --onefile \
-#     --distpath $DISTARMPATH \
-#     --target-arch arm64 \
-#     --add-data "$SRCINTLPATH:staking_deposit/intl" \
-#     -p $PYTHONPATH \
-#     $SCRIPTPATH/eth2deposit_proxy.py
+PYTHONPATH=$PYTHONPATH pyinstaller \
+    --distpath $DISTARMPATH \
+    --target-arch arm64 \
+    --add-data "$SRCINTLPATH:staking_deposit/intl" \
+    -p $PYTHONPATH \
+    $SCRIPTPATH/eth2deposit_proxy.py
 
 # Adding word list
 cp $SRCWORDSPATH/* $DISTWORDSPATH

--- a/src/scripts/bundle_proxy_mac.sh
+++ b/src/scripts/bundle_proxy_mac.sh
@@ -46,7 +46,7 @@ PYTHONPATH=$PYTHONPATH pyinstaller \
     $SCRIPTPATH/eth2deposit_proxy.py
 PYTHONPATH=$PYTHONPATH pyinstaller \
     --onefile \
-    --distpath $DISTX64ARCHPATH \
+    --distpath $DISTARM64ARCHPATH \
     --target-arch arm64 \
     --add-data "$SRCINTLPATH:staking_deposit/intl" \
     -p $PYTHONPATH \

--- a/src/scripts/bundle_proxy_mac.sh
+++ b/src/scripts/bundle_proxy_mac.sh
@@ -21,13 +21,14 @@ DISTBINPATH=$SCRIPTPATH/../../build/bin
 DISTWORDSPATH=$SCRIPTPATH/../../build/word_lists
 SRCWORDSPATH=$SCRIPTPATH/../vendors/$EDCDIR/staking_deposit/key_handling/key_derivation/word_lists
 SRCINTLPATH=$SCRIPTPATH/../vendors/$EDCDIR/staking_deposit/intl
-DISTARCHPATH=$SCRIPTPATH/../../.build
-DISTARMPATH=$DISTARCHPATH/bin-arm64
-DISTX64PATH=$DISTARCHPATH/bin-x64
+DISTARCHROOTPATH=$SCRIPTPATH/../../.build
+DISTX64ARCHPATH=$DISTARCHROOTPATH/x64
+DISTARM64ARCHPATH=$DISTACHROOTPATH/arm64
 
-mkdir -p $DISTARMPATH
-mkdir -p $DISTX64PATH
-mkdir -p $DISTBINPATH
+rm -rf $DISTARCHROOTPATH
+rm -rf $DISTBINPATH
+mkdir -p $DISTX64ARCHPATH
+mkdir -p $DISTARM64ARCHPATH
 mkdir -p $DISTWORDSPATH
 mkdir -p $TARGETPACKAGESPATH
 
@@ -38,14 +39,17 @@ python3 -m pip install -r $ETH2REQUIREMENTSPATH --target $TARGETPACKAGESPATH
 # Bundling Python eth2deposit_proxy
 PYTHONPATH=$PYTHONPATH pyinstaller \
     --onefile \
-    --distpath $DISTARCHPATH \
-    --target-arch universal2 \
+    --distpath $DISTX64ARCHPATH \
+    --target-arch x86_64 \
     --add-data "$SRCINTLPATH:staking_deposit/intl" \
     -p $PYTHONPATH \
     $SCRIPTPATH/eth2deposit_proxy.py
-lipo -extract arm64 $DISTARCHPATH/eth2deposit_proxy -output $DISTARMPATH/eth2deposit_proxy
-lipo -extract x86_64 $DISTARCHPATH/eth2deposit_proxy -output $DISTX64PATH/eth2deposit_proxy
-
-
+PYTHONPATH=$PYTHONPATH pyinstaller \
+    --onefile \
+    --distpath $DISTX64ARCHPATH \
+    --target-arch arm64 \
+    --add-data "$SRCINTLPATH:staking_deposit/intl" \
+    -p $PYTHONPATH \
+    $SCRIPTPATH/eth2deposit_proxy.py
 # Adding word list
 cp $SRCWORDSPATH/* $DISTWORDSPATH


### PR DESCRIPTION
A single mac build causes problems with Mx machines due to the way
pyinstaller packages files and lipo destroys that connection.
