### PR TITLE
fix: Revert and retest all builds. Python 3.11.4 was affecting everything but reverting requires re-linking with repaired version of CLI.

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -45,7 +45,7 @@ jobs:
         if: ${{ matrix.os != 'macos' }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11.4"
+          python-version: "3.11.3"
       - name: Set up Python (mac)
         if: ${{ matrix.os == 'macos' }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
Retest all builds.

- [x] Tested ubuntu pyinstaller package
- [x] Tested mac universal pyinstall package
  - [x] Running rosetta x86_64
  - [x] Running native arm64
- [x] Tested windows pyinstaller package
